### PR TITLE
chore/sc-125273/remove-when-js-usages-and-dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "particle-library-manager": "^0.1.13",
         "semver": "^5.1.0",
         "underscore": "^1.8.3",
-        "when": "^3.7.2",
         "winreg": "^1.2.2",
         "yeoman-environment": "^1.6.6",
         "yeoman-generator": "^1.1.1"
@@ -9773,11 +9772,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/when": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
-      "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I="
-    },
     "node_modules/which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -18141,11 +18135,6 @@
         "strip-bom-stream": "^2.0.0",
         "vinyl": "^2.0.1"
       }
-    },
-    "when": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
-      "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "particle-library-manager": "^0.1.13",
     "semver": "^5.1.0",
     "underscore": "^1.8.3",
-    "when": "^3.7.2",
     "winreg": "^1.2.2",
     "yeoman-environment": "^1.6.6",
     "yeoman-generator": "^1.1.1"

--- a/src/cmd/command.js
+++ b/src/cmd/command.js
@@ -1,5 +1,3 @@
-import when from 'when';
-
 /**
  * Describes the interface expected of objects passed as the command site to a command.
  */
@@ -22,11 +20,13 @@ class CommandSite {
 	end(state, cmd) {}
 
 
-	run(cmd, state = {}) {
-		return when()
-		.then(() => this.begin(state, this))
-		.then(() => cmd.run(state, this))
-		.finally(() => this.end(state, this));
+	async run(cmd, state = {}) {
+		try {
+			await this.begin(state, this);
+			await cmd.run(state, this);
+		} finally {
+			await this.end(state, this);
+		}
 	}
 }
 


### PR DESCRIPTION
### Description

This PR will remove `when.js` dependency from the library and change it for async/await strategy.

**Next changes in follow PR's**
* Remove yeoman: https://app.shortcut.com/particle/story/12348
* Use `Common js` as standard: https://app.shortcut.com/particle/story/125321

### How test
* Pull down the branch: `git pull && git checkout chore/sc-125273/remove-when-js-usages-and-dependency`
* Run tests: `npm test`
* Attempt to use the library as before

**Outcome**
* Test should pass
* Library should work as before the changes


### Related / Discussions
Story details: https://app.shortcut.com/particle/story/125273/remove-when-js-usages-and-dependency
Epic: https://app.shortcut.com/particle/epic/125144?cf_workflow=500127125&ct_workflow=all&group_by=none&vc_group_by=day

