### PR TITLE
make command always returns the execution

### DIFF
--- a/src/cmd/command.js
+++ b/src/cmd/command.js
@@ -23,7 +23,7 @@ class CommandSite {
 	async run(cmd, state = {}) {
 		try {
 			await this.begin(state, this);
-			await cmd.run(state, this);
+			return await cmd.run(state, this);
 		} finally {
 			await this.end(state, this);
 		}

--- a/src/cmd/library_add.js
+++ b/src/cmd/library_add.js
@@ -51,7 +51,7 @@ export class LibraryAddCommand {
 		await this.loadProject();
 		const library = await this.fetchLibrary(lib.name, lib.version);
 		await this.addLibraryToProject(library);
-		await this.saveProject();
+		return this.saveProject();
 	}
 
 	ensureProjectExists(directory) {
@@ -88,7 +88,7 @@ export class LibraryAddCommand {
 
 	async addLibraryToProject(library) {
 		await this.site.addedLibrary(library.name, library.version);
-		await this.properties.addDependency(library.name, library.version);
+		return this.properties.addDependency(library.name, library.version);
 	}
 
 	saveProject() {


### PR DESCRIPTION
### Description
This PR will get back the right behavior of CommandSite class making return the result of the execution from command.
It was removed in this PR https://github.com/particle-iot/particle-commands/pull/25 but it's wrong given that other dependencies requires the result of the execution